### PR TITLE
Remove cyclic dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3363,6 +3363,32 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@rollup/plugin-commonjs": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.0.0.tgz",
@@ -3707,12 +3733,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.1.tgz",
-      "integrity": "sha512-06lfjo76naNeOMDl+mWG9Fh/a0UHKLGhin+mGaIw72FUMbMGBkdi/FEJmgEDzh4eE73KIYzHWvOCYJ0ak7nrJQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.0.1.tgz",
+      "integrity": "sha512-pQZtXupCn11O4AwpYVUX4PDFfmIJl90ZgrEBg0CEcqlwvPiG0uY81fimr1oMFblZnpKAq6prrT9a59pj1x58rw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.6.1",
+        "@typescript-eslint/experimental-utils": "4.0.1",
+        "@typescript-eslint/scope-manager": "4.0.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -3721,14 +3748,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.1.tgz",
-      "integrity": "sha512-oS+hihzQE5M84ewXrTlVx7eTgc52eu+sVmG7ayLfOhyZmJ8Unvf3osyFQNADHP26yoThFfbxcibbO0d2FjnYhg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.0.1.tgz",
+      "integrity": "sha512-gAqOjLiHoED79iYTt3F4uSHrYmg/GPz/zGezdB0jAdr6S6gwNiR/j7cTZ8nREKVzMVKLd9G3xbg1sV9GClW3sw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.6.1",
-        "@typescript-eslint/typescript-estree": "3.6.1",
+        "@typescript-eslint/scope-manager": "4.0.1",
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/typescript-estree": "4.0.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
@@ -3792,22 +3820,32 @@
         }
       }
     },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.0.1.tgz",
+      "integrity": "sha512-u3YEXVJ8jsj7QCJk3om0Y457fy2euEOkkzxIB/LKU3MdyI+FJ2gI0M4aKEaXzwCSfNDiZ13a3lDo5DVozc+XLQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/visitor-keys": "4.0.1"
+      }
+    },
     "@typescript-eslint/types": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.1.tgz",
-      "integrity": "sha512-NPxd5yXG63gx57WDTW1rp0cF3XlNuuFFB5G+Kc48zZ+51ZnQn9yjDEsjTPQ+aWM+V+Z0I4kuTFKjKvgcT1F7xQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.0.1.tgz",
+      "integrity": "sha512-S+gD3fgbkZYW2rnbjugNMqibm9HpEjqZBZkTiI3PwbbNGWmAcxolWIUwZ0SKeG4Dy2ktpKKaI/6+HGYVH8Qrlg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.6.1.tgz",
-      "integrity": "sha512-G4XRe/ZbCZkL1fy09DPN3U0mR6SayIv1zSeBNquRFRk7CnVLgkC2ZPj8llEMJg5Y8dJ3T76SvTGtceytniaztQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.0.1.tgz",
+      "integrity": "sha512-zGzleORFXrRWRJAMLTB2iJD1IZbCPkg4hsI8mGdpYlKaqzvKYSEWVAYh14eauaR+qIoZVWrXgYSXqLtTlxotiw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.6.1",
-        "@typescript-eslint/visitor-keys": "3.6.1",
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/visitor-keys": "4.0.1",
         "debug": "^4.1.1",
-        "glob": "^7.1.6",
+        "globby": "^11.0.1",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
         "semver": "^7.3.2",
@@ -3815,12 +3853,21 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.1.tgz",
-      "integrity": "sha512-qC8Olwz5ZyMTZrh4Wl3K4U6tfms0R/mzU4/5W3XeUZptVraGVmbptJbn6h2Ey6Rb3hOs3zWoAUebZk8t47KGiQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.0.1.tgz",
+      "integrity": "sha512-yBSqd6FjnTzbg5RUy9J+9kJEyQjTI34JdGMJz+9ttlJzLCnGkBikxw+N5n2VDcc3CesbIEJ0MnZc5uRYnrEnCw==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "@typescript-eslint/types": "4.0.1",
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
+        }
       }
     },
     "abab": {
@@ -3942,6 +3989,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-unique": {
@@ -4666,6 +4719,15 @@
       "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -5378,6 +5440,20 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5389,6 +5465,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -5607,6 +5692,28 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        }
+      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -7587,6 +7694,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -7977,6 +8090,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "performance-now": {
@@ -8391,6 +8510,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -8410,31 +8535,22 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.1.tgz",
-      "integrity": "sha512-RJl77Bbj1EunAQDC3dK/O2HWuSUX3oJbRGzyLoS5o9W4Hs1Nix3Gavqj1Lzs5Y6Ff4H2xXfmZ1WWUQCYocSbzQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.2.tgz",
+      "integrity": "sha512-zarMH2F8oT/NO6p20gl/jkts+WxyzOlhOIUwUU/EDx5e6ewdDPS/flwLj5XFuijUCr64bZwqKuRVwCPdXXYefQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8",
+        "@rollup/pluginutils": "^3.1.0",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "8.1.0",
-        "resolve": "1.15.1",
-        "tslib": "1.11.2"
+        "resolve": "1.17.0",
+        "tslib": "2.0.1"
       },
       "dependencies": {
-        "resolve": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
           "dev": true
         }
       }
@@ -8443,6 +8559,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "safe-buffer": {
@@ -9335,9 +9457,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^26.0.5",
     "@types/marked": "^1.1.0",
     "@types/node": "^14.0.23",
-    "@typescript-eslint/eslint-plugin": "^3.6.1",
+    "@typescript-eslint/eslint-plugin": "^4.0.1",
     "eslint": "^7.8.1",
     "eslint-config-verit": "^2.1.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
@@ -18,9 +18,9 @@
     "jest-ts-webcompat-resolver": "^1.0.0",
     "prettier": "^2.0.5",
     "rollup": "^2.23.0",
-    "rollup-plugin-typescript2": "^0.27.1",
+    "rollup-plugin-typescript2": "^0.27.2",
     "ts-jest": "^26.1.3",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.2"
   },
   "scripts": {
     "build": "rollup --config",

--- a/public/style.css
+++ b/public/style.css
@@ -29,98 +29,6 @@ canvas {
     bottom: 0;
 }
 
-#arena {
-	position: absolute;
-	top: 0px;
-    left: 0px;
-    transform-origin: top left;
-}
-
-#tiles {
-    font-size: 0;
-}
-
-.row {
-    white-space: nowrap;
-}
-
-.tile {
-    width: 32px;
-    height: 32px;
-    background-color: white;
-    display: inline-block;
-}
-
-.tile.open { background-color: green; }
-.tile.block { background-color: #555; }
-.tile.start { background-color: #569656; }
-.tile.end { background-color: #569656; }
-.tile.spawn { background-color: green; }
-.tile.void { opacity: 0; }
-
-.layer-0 { opacity: 1.0; }
-.layer-1 { opacity: 0.9; }
-.layer-2 { opacity: 0.8; }
-.layer-3 { opacity: 0.7; }
-.layer-4 { opacity: 0.6; }
-.layer-5 { opacity: 0.5; }
-.layer-6 { opacity: 0.4; }
-.layer-7 { opacity: 0.3; }
-.layer-8 { opacity: 0.2; }
-.layer-9 { opacity: 0.1; }
-
-.sprite {
-    filter: drop-shadow(0.125em 0.1875em 0.375em rgba(0,0,0,0.5));
-    position: absolute;
-}
-.sprite:hover:not(.doodad) {
-    filter: drop-shadow(0.125em 0.1875em 0.5em rgba(0,0,0,0.6));
-    cursor: pointer;
-}
-.sprite.selected {
-    filter: drop-shadow(0.125em 0.1875em 0.375em var(--bluecolor))
-        drop-shadow(0.125em 0.1875em 0.375em var(--bluecolor));
-}
-.sprite.selected:hover {
-    filter: drop-shadow(0.125em 0.1875em 0.5em var(--bluecolor))
-        drop-shadow(0.125em 0.1875em 0.5em var(--bluecolor))
-        drop-shadow(0.125em 0.1875em 0.5em var(--bluecolor));
-}
-
-.blueprint {
-	background-color: var(--bluebg);
-}
-
-@keyframes death {
-    0% { transform: scale(1); }
-    10% { transform: scale(0.75); }
-    20% { transform: scale(0.85); }
-    100% { transform: scale(0); }
-}
-.death {
-    animation: death 125ms forwards;
-}
-
-@keyframes ascend {
-    0% { transform: scale(1); opacity: 1; }
-    10% { transform: scale(3); opacity: 1; }
-    20% { transform: scale(2); opacity: 1; }
-    100% { transform: scale(10); opacity: 0; }
-}
-.ascend {
-    animation: ascend 1s forwards;
-}
-
-@keyframes attack {
-	0% { transform: scale(1); filter: hue-rotate(0deg); }
-	40% { transform: scale(0.8); filter: hue-rotate(-15deg); }
-	90% { transform: scale(1.2); filter: hue-rotate(35deg); }
-	0% { transform: scale(1); filter: hue-rotate(0deg); }
-}
-.attack {
-    animation: attack 250ms;
-}
-
 #top-right {
     position: absolute;
     top: 1em;
@@ -317,10 +225,3 @@ button:hover {
 #hotkeys .highlight { color: gold; }
 
 #hotkeys .description { font-size: 75% }
-
-@keyframes resource {
-	0% { transform: rotate(0deg); }
-	90% { transform: rotate(0deg); }
-	100% { transform: rotate(180deg); }
-}
-.sprite.resource { animation: resource 2s infinite; }

--- a/src/Round.ts
+++ b/src/Round.ts
@@ -15,6 +15,7 @@ import { Sprite } from "./entities/sprites/Sprite";
 import { Game } from "./Game";
 import { TileSystem } from "./systems/TileSystem";
 import { SceneObjectComponent } from "./components/graphics/SceneObjectComponent";
+import { currentGame } from "./gameContext";
 
 let placeholderPlayer: Player;
 
@@ -62,15 +63,13 @@ class Round {
 		time,
 		settings,
 		players,
-		game,
 	}: {
 		time: number;
 		settings: Settings;
 		players: Player[];
-		game: Game;
 	}) {
 		emitter(this);
-		this.game = game;
+		this.game = currentGame();
 		// We set this for downstream constructor logic
 		this.game.round = this;
 		this.lastUpdate = time;
@@ -91,7 +90,7 @@ class Round {
 				color: colors.white,
 				id: -1,
 				score: { bulldog: 800 },
-				game,
+				game: this.game,
 			});
 
 		this.pickTeams();
@@ -192,7 +191,6 @@ class Round {
 			graphic: { shape: "circle" },
 			x,
 			y,
-			game: this.game,
 			radius,
 		});
 		const mesh = SceneObjectComponent.get(sprite)!.object;

--- a/src/components/Circle.ts
+++ b/src/components/Circle.ts
@@ -1,9 +1,8 @@
 import { Component } from "../core/Component";
-import { Sprite } from "../entities/sprites/Sprite";
 import { SelectionCircle } from "../entities/SelectionCircle";
 import { getEntityXY } from "../components/Position";
 import { Entity } from "../core/Entity";
-import { App } from "../core/App";
+import { currentGame } from "../gameContext";
 
 type Props = {
 	radius: number;
@@ -11,6 +10,10 @@ type Props = {
 };
 
 type InternalProps = Props & { x: number; y: number };
+
+const hasRadius = (
+	object: Record<string, unknown>,
+): object is { radius: number } => typeof object.radius === "number";
 
 export abstract class Circle extends Component<[InternalProps]> {
 	protected static map = new WeakMap<Entity, Circle>();
@@ -25,7 +28,7 @@ export abstract class Circle extends Component<[InternalProps]> {
 
 		super.clear(entity);
 
-		App.current?.remove(selected.circle);
+		currentGame().remove(selected.circle);
 
 		return true;
 	}
@@ -36,8 +39,7 @@ export abstract class Circle extends Component<[InternalProps]> {
 		const xy = getEntityXY(entity);
 		super(entity, {
 			radius:
-				props.radius ??
-				(Sprite.isSprite(entity) ? entity.radius * 1.25 : 1),
+				props.radius ?? (hasRadius(entity) ? entity.radius * 1.25 : 1),
 			color: props.color ?? "#00FF00",
 			x: xy?.x ?? 0,
 			y: xy?.y ?? 0,

--- a/src/components/MoveTarget.ts
+++ b/src/components/MoveTarget.ts
@@ -55,7 +55,7 @@ export class MoveTarget extends DeprecatedComponent<Sprite> {
 			Math.abs(
 				distanceBetweenPoints(
 					path.target,
-					Sprite.isSprite(target) ? target.position : target,
+					"x" in target && "y" in target ? target : target.position,
 				) - distance,
 			) < 1e-7
 		)
@@ -65,7 +65,6 @@ export class MoveTarget extends DeprecatedComponent<Sprite> {
 	}
 
 	recalc(): void {
-		if (!Sprite.isSprite(this.entity)) return;
 		this.path = calcAndTweenShortenedPath(
 			this.entity,
 			this.target,

--- a/src/components/Position.ts
+++ b/src/components/Position.ts
@@ -1,6 +1,5 @@
 import { Component } from "../core/Component";
 import { Entity } from "../core/Entity";
-import { Sprite } from "../entities/sprites/Sprite";
 import { Point } from "../pathing/PathingMap";
 
 export class Position extends Component<
@@ -40,11 +39,20 @@ export class Position extends Component<
 	}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hasPositionProp = (entity: any): entity is { position: Point } =>
+	entity &&
+	typeof entity === "object" &&
+	entity.position &&
+	typeof entity.position === "object" &&
+	typeof entity.position.x === "number" &&
+	typeof entity.position.y === "number";
+
 export const getEntityXY = (entity: Entity): Point | undefined => {
 	const position = Position.get(entity);
 	if (position) return { x: position.x, y: position.y };
 
-	if (Sprite.isSprite(entity))
+	if (hasPositionProp(entity))
 		return { x: entity.position.x, y: entity.position.y };
 
 	return;

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -1,17 +1,11 @@
 import { System } from "./System";
 import { Mechanism } from "./Merchanism";
 import { requestAnimationFrame } from "../util/globals";
-import { DeprecatedComponentConstructor } from "./Component";
+import { DeprecatedComponentConstructor, Component } from "./Component";
 import { Entity } from "./Entity";
-import { Context } from "./Context";
+import { withApp } from "./appContext";
 
 export class App {
-	static context = new Context<App | undefined>(undefined);
-
-	static get current(): App | undefined {
-		return App.context.current;
-	}
-
 	protected systems: System[] = [];
 	protected mechanisms: Mechanism[] = [];
 	private lastRender = 0;
@@ -22,6 +16,7 @@ export class App {
 		DeprecatedComponentConstructor<any>,
 		System[]
 	>();
+	private components: typeof Component[] = [];
 	// TODO: make this private!
 	lastUpdate = 0;
 
@@ -78,6 +73,9 @@ export class App {
 	remove(...entities: Entity[]): App {
 		for (const system of this.systems) system.remove(...entities);
 
+		for (const entity of entities)
+			for (const component of this.components) component.clear(entity);
+
 		return this;
 	}
 
@@ -120,7 +118,7 @@ export class App {
 	}
 
 	render(): void {
-		App.context.with(this, () => this._render());
+		withApp(this, () => this._render());
 	}
 
 	protected _update(e: { time: number }): void {
@@ -147,7 +145,7 @@ export class App {
 	 * The logical loop.
 	 */
 	update(e: { time: number }): void {
-		App.context.with(this, () => this._update(e));
+		withApp(this, () => this._update(e));
 	}
 
 	get time(): number {

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -1,6 +1,6 @@
 import { Entity } from "./Entity";
 import { hasAppProp } from "./util";
-import { App } from "./App";
+import { currentApp } from "./appContext";
 
 export abstract class DeprecatedComponent<T extends Entity = Entity> {
 	readonly entity: T;
@@ -44,7 +44,7 @@ export abstract class Component<
 		const cleared = this.map.delete(entity);
 
 		if (cleared) {
-			const app = App.current;
+			const app = currentApp();
 			if (app)
 				app.entityComponentUpdated(
 					entity,

--- a/src/core/appContext.ts
+++ b/src/core/appContext.ts
@@ -1,0 +1,12 @@
+import { Context } from "./Context";
+import { App } from "./App";
+
+const context = new Context<App | undefined>(undefined);
+
+export const withApp = context.with.bind(context);
+export const wrapApp = context.wrap.bind(context);
+export const currentApp = (): App => {
+	const app = context.current;
+	if (!app) throw new Error("Expected an App context");
+	return app;
+};

--- a/src/entities/SelectionCircle.ts
+++ b/src/entities/SelectionCircle.ts
@@ -1,7 +1,7 @@
 import { TorusBufferGeometry, MeshBasicMaterial, Mesh } from "three";
 import { SceneObjectComponent } from "../components/graphics/SceneObjectComponent";
 import { Position } from "../components/Position";
-import { App } from "../core/App";
+import { currentGame } from "../gameContext";
 
 export class SelectionCircle {
 	id = "SELECTION_CIRCLE";
@@ -27,6 +27,6 @@ export class SelectionCircle {
 		new SceneObjectComponent(this, mesh);
 		new Position(this, x, y);
 
-		App.current?.add(this);
+		currentGame().add(this);
 	}
 }

--- a/src/entities/sprites/Sprite.ts
+++ b/src/entities/sprites/Sprite.ts
@@ -17,6 +17,7 @@ import { HoldPositionManager } from "../../components/HoldPositionComponent";
 import { GerminateComponentManager } from "../../components/GerminateComponent";
 import { Selected } from "../../components/Selected";
 import { App } from "../../core/App";
+import { currentGame } from "../../gameContext";
 
 export type SpriteElement = HTMLDivElement & { sprite: Sprite };
 
@@ -35,7 +36,6 @@ export type SpriteProps = {
 	maxHealth?: number;
 	owner?: Player;
 	facing?: number;
-	game: Game;
 	graphic?: MeshBuilderComponentProps;
 };
 
@@ -52,10 +52,7 @@ export type SpriteEvents = {
 };
 
 class Sprite {
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	static isSprite = (object: Object): object is Sprite =>
-		object instanceof Sprite;
-
+	readonly isSprite = true;
 	app: App;
 	game: Game;
 	radius: number;
@@ -112,10 +109,11 @@ class Sprite {
 		health = maxHealth,
 		facing = (3 / 2) * Math.PI,
 		owner,
-		game,
 		graphic = clone(Sprite.defaults.graphic),
 	}: SpriteProps) {
 		emitter<Sprite, SpriteEvents>(this);
+
+		const game = currentGame();
 
 		if (!game.round)
 			throw new Error("trying to create a sprite outside a round");

--- a/src/entities/sprites/Unit.ts
+++ b/src/entities/sprites/Unit.ts
@@ -123,7 +123,6 @@ class Unit extends Sprite {
 		...props
 	}: UnitProps) {
 		super({
-			game: props.owner.game,
 			...props,
 			graphic: {
 				...Unit.defaults.graphic,

--- a/src/entities/sprites/obstructions/Blueprint.ts
+++ b/src/entities/sprites/obstructions/Blueprint.ts
@@ -2,6 +2,7 @@ import { Sprite } from "../Sprite";
 import { Obstruction } from "./Obstruction";
 import { Game } from "../../../Game";
 
+// TODO: this should have to extend Sprite (health/owner are silly)
 export class Blueprint extends Sprite {
 	static buildTime = 0;
 

--- a/src/entities/sprites/projectiles/Projectile.ts
+++ b/src/entities/sprites/projectiles/Projectile.ts
@@ -61,7 +61,6 @@ export class Projectile extends Sprite {
 	}: ProjectileProps) {
 		super({
 			...Projectile.clonedDefaults,
-			game: props.owner.game,
 			x: producer.position.x,
 			y: producer.position.y,
 			...props,

--- a/src/entities/sprites/spriteLogic.ts
+++ b/src/entities/sprites/spriteLogic.ts
@@ -2,11 +2,12 @@ import { Unit } from "./Unit";
 import { Crosser } from "./Crosser";
 import { Obstruction } from "./obstructions/Obstruction";
 import { Defender } from "./Defender";
-import { Sprite } from "./Sprite";
 import { obstructionMap } from "./obstructions/index";
 import { Game } from "../../Game";
 import { Player } from "../../players/Player";
 import { MouseEvents } from "../../systems/Mouse";
+import { isSprite } from "../../typeguards";
+import { currentGame } from "../../gameContext";
 
 export type Action = {
 	description?: string;
@@ -54,10 +55,10 @@ export type Action = {
 
 const rightClick: MouseEvents["mouseDown"] = ({ mouse }) => {
 	const { x, y } = mouse.ground;
-	const game = Game.current;
+	const game = currentGame();
 
 	const ownedSprites = game.selectionSystem.selection.filter(
-		(s) => Sprite.isSprite(s) && s.owner === game.localPlayer,
+		(s) => isSprite(s) && s.owner === game.localPlayer,
 	);
 
 	const units = ownedSprites.filter((u) => u instanceof Unit);
@@ -93,7 +94,7 @@ const rightClick: MouseEvents["mouseDown"] = ({ mouse }) => {
 };
 
 const leftClick: MouseEvents["mouseDown"] = ({ mouse }) => {
-	const game = Game.current;
+	const game = currentGame();
 
 	const obstructionPlacement = game.obstructionPlacement;
 	if (!obstructionPlacement) return;
@@ -107,9 +108,7 @@ const leftClick: MouseEvents["mouseDown"] = ({ mouse }) => {
 
 	const builder = game.selectionSystem.selection.find(
 		(s): s is Crosser =>
-			Sprite.isSprite(s) &&
-			s.owner === game.localPlayer &&
-			Crosser.isCrosser(s),
+			isSprite(s) && s.owner === game.localPlayer && Crosser.isCrosser(s),
 	);
 
 	if (!builder) return;
@@ -146,7 +145,7 @@ export const initSpriteLogicListeners = (game: Game): void => {
 		if (hotkey.type === "build") {
 			const ownerCrossers = game.selectionSystem.selection.filter(
 				(u): u is Crosser =>
-					Sprite.isSprite(u) &&
+					isSprite(u) &&
 					u.owner === game.localPlayer &&
 					u.constructor === Crosser,
 			);

--- a/src/gameContext.ts
+++ b/src/gameContext.ts
@@ -1,0 +1,27 @@
+import { Context } from "./core/Context";
+import { Game } from "./Game";
+import { withApp, wrapApp } from "./core/appContext";
+import { Round } from "./Round";
+
+const context = new Context<Game | undefined>(undefined);
+
+export const withGame = <T>(game: Game, fn: (game: Game) => T): T =>
+	withApp(game, () => context.with(game, fn));
+
+export const wrapGame = <Args extends unknown[], Return extends unknown>(
+	game: Game,
+	fn: (...args: Args) => Return,
+): ((...args: Args) => Return) => wrapApp(game, context.wrap(game, fn));
+
+export const currentGame = (): Game => {
+	const game = context.current;
+	if (!game) throw new Error("Expected an Game context");
+	return game;
+};
+
+export const currentRound = (): Round => {
+	const game = currentGame();
+	const round = game.round;
+	if (!round) throw new Error("Expected a Round to be in progress");
+	return round;
+};

--- a/src/players/camera.ts
+++ b/src/players/camera.ts
@@ -5,8 +5,8 @@ import { registerCommand } from "../ui/chat";
 import { Round } from "../Round";
 import { Point } from "../pathing/PathingMap";
 import { UI } from "../ui/index";
-import { Game } from "../Game";
-import { Sprite } from "../entities/sprites/Sprite";
+import { isSprite } from "../typeguards";
+import { currentGame, wrapGame } from "../gameContext";
 
 type Direction = "right" | "left" | "down" | "up";
 
@@ -44,7 +44,7 @@ const setMouseAndRender = (direction: Direction) => {
 };
 
 const setZoom = (zoom: number) => {
-	const camera = Game.current.graphics.camera;
+	const camera = currentGame().graphics.camera;
 	if (camera) camera.position.z = zoom;
 };
 
@@ -103,7 +103,7 @@ export const initCameraListeners = (ui: UI): void => {
 	});
 
 	ui.addEventListener("wheel", ({ deltaY }) => {
-		const camera = Game.current.graphics.camera;
+		const camera = currentGame().graphics.camera;
 		if (camera) setZoom(camera.position.z + deltaY * ZOOM_SPEED);
 	});
 };
@@ -113,7 +113,7 @@ const renderCamera = (time?: number) => {
 	const delta = (lastRender && time ? time - lastRender : 17) / 1000;
 	lastRender = time;
 
-	const game = Game.current;
+	const game = currentGame();
 	const graphics = game.graphics;
 
 	if (pan) {
@@ -124,7 +124,7 @@ const renderCamera = (time?: number) => {
 
 		if (x !== pan.target.x || y !== pan.target.y)
 			requestedAnimationFrame = requestAnimationFrame(
-				Game.wrap(game, renderCamera),
+				wrapGame(game, renderCamera),
 			);
 		else requestedAnimationFrame = undefined;
 	} else {
@@ -165,7 +165,7 @@ const renderCamera = (time?: number) => {
 			Object.values(mouse).some(Boolean)
 		)
 			requestedAnimationFrame = requestAnimationFrame(
-				Game.wrap(game, renderCamera),
+				wrapGame(game, renderCamera),
 			);
 		else requestedAnimationFrame = undefined;
 	}
@@ -198,10 +198,10 @@ export const panTo = ({
 };
 
 const follow = () => {
-	const selection = Game.current.selectionSystem.selection;
+	const selection = currentGame().selectionSystem.selection;
 	if (!selection?.length) return;
 
-	const { xSum, ySum } = selection.filter(Sprite.isSprite).reduce(
+	const { xSum, ySum } = selection.filter(isSprite).reduce(
 		({ xSum, ySum }, { position: { x, y } }) => ({
 			xSum: xSum + x,
 			ySum: ySum + y,

--- a/src/systems/Mouse.ts
+++ b/src/systems/Mouse.ts
@@ -10,7 +10,7 @@ import { Hover } from "../components/Hover";
 import { Emitter, emitter } from "../emitter";
 import { UI, MouseMoveEvent, MouseDownEvent } from "../ui";
 import { SelectionCircle } from "../entities/SelectionCircle";
-import { Sprite } from "../entities/sprites/Sprite";
+import { isSprite } from "../typeguards";
 
 export enum MouseButton {
 	LEFT = 0,
@@ -120,7 +120,7 @@ class Mouse extends System {
 		for (let i = 0; i < this.intersections.length; i++) {
 			const object: EntityObject = this.intersections[i].object;
 			const entity = object?.entity;
-			if (entity && (!Sprite.isSprite(entity) || entity.selectable)) {
+			if (entity && (!isSprite(entity) || entity.selectable)) {
 				foundEntity = true;
 				if (this.entity !== entity) {
 					if (this.entity) Hover.clear(this.entity);

--- a/src/systems/MoveSystem.ts
+++ b/src/systems/MoveSystem.ts
@@ -2,13 +2,14 @@ import { System } from "../core/System";
 import { MoveTargetManager, MoveTarget } from "../components/MoveTarget";
 import { Sprite } from "../entities/sprites/Sprite";
 import { PathingMap, Point } from "../pathing/PathingMap";
+import { isSprite } from "../typeguards";
 
 const withoutTarget = <A>(
 	pathingMap: PathingMap,
 	target: Point | Sprite,
 	fn: () => A,
 ): A => {
-	if (Sprite.isSprite(target)) return pathingMap.withoutEntity(target, fn);
+	if (isSprite(target)) return pathingMap.withoutEntity(target, fn);
 
 	return fn();
 };

--- a/src/systems/SelectedSystem.ts
+++ b/src/systems/SelectedSystem.ts
@@ -2,9 +2,9 @@ import { isEqual } from "lodash-es";
 import { System } from "../core/System";
 import { Selected } from "../components/Selected";
 import { Entity } from "../core/Entity";
-import { Game } from "../Game";
 import { MouseButton } from "./Mouse";
 import { Unit } from "../entities/sprites/Unit";
+import { currentGame } from "../gameContext";
 
 type SelectedEntity = Entity & { __selected: true };
 
@@ -19,9 +19,9 @@ export class SelectedSystem extends System {
 	constructor() {
 		super();
 
-		const game = Game.current;
+		const game = currentGame();
 
-		game?.mouse.addEventListener(
+		game.mouse.addEventListener(
 			"mouseDown",
 			({ button, mouse: { entity } }) => {
 				if (
@@ -42,13 +42,13 @@ export class SelectedSystem extends System {
 		const selected = Selected.get(entity);
 		if (!selected) throw new Error("expected Selected component");
 		this.data.set(entity, selected);
-		Game.current.dispatchEvent("selection", Array.from(this));
+		currentGame().dispatchEvent("selection", Array.from(this));
 	}
 
 	onRemoveEntity(entity: Entity): void {
 		const selected = this.data.get(entity);
 		if (!selected) return;
-		Game.current.dispatchEvent("selection", Array.from(this));
+		currentGame().dispatchEvent("selection", Array.from(this));
 	}
 
 	get selection(): ReadonlyArray<Entity> {
@@ -57,7 +57,7 @@ export class SelectedSystem extends System {
 
 	select(entity: Entity): boolean {
 		if (this.test(entity)) return false;
-		const game = Game.current;
+		const game = currentGame();
 
 		new Selected(entity, {
 			color:
@@ -79,7 +79,7 @@ export class SelectedSystem extends System {
 
 		for (const curSelected of this) Selected.clear(curSelected);
 
-		const game = Game.current;
+		const game = currentGame();
 		for (const newSelected of entities)
 			new Selected(newSelected, {
 				color:

--- a/src/systems/ThreeGraphics.ts
+++ b/src/systems/ThreeGraphics.ts
@@ -1,5 +1,4 @@
 import { System } from "../core/System";
-import { Sprite } from "../entities/sprites/Sprite";
 import { document, window } from "../util/globals";
 import { Unit } from "../entities/sprites/Unit";
 import { MoveTargetManager } from "../components/MoveTarget";
@@ -22,6 +21,7 @@ import { Position } from "../components/Position";
 import { Game } from "../Game";
 import { Selected } from "../components/Selected";
 import { Hover } from "../components/Hover";
+import { isSprite } from "../typeguards";
 
 const getCanvas = () => {
 	const canvas = document.createElement("canvas");
@@ -168,7 +168,7 @@ export class ThreeGraphics extends System {
 			updateHealth: true,
 			knownObject: object,
 		};
-		if (Sprite.isSprite(entity)) {
+		if (isSprite(entity)) {
 			data.onChangePositionListener = () => {
 				this.dirty.add(entity);
 				data.updatePosition = true;
@@ -191,7 +191,7 @@ export class ThreeGraphics extends System {
 		const object = this.entityData.get(entity)?.knownObject;
 		if (object) this.scene.remove(object);
 
-		if (Sprite.isSprite(entity)) {
+		if (isSprite(entity)) {
 			const data = this.entityData.get(entity);
 			if (data) {
 				if (data.onChangePositionListener)
@@ -232,7 +232,7 @@ export class ThreeGraphics extends System {
 
 		let stillDirty = false;
 
-		if (Sprite.isSprite(entity)) {
+		if (isSprite(entity)) {
 			const moveTarget = MoveTargetManager.get(entity);
 			if (moveTarget && Unit.isUnit(entity)) {
 				moveTarget.renderProgress += entity.speed * delta;

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -1,0 +1,5 @@
+import { Sprite } from "./entities/sprites/Sprite";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+export const isSprite = (obj: any): obj is Sprite =>
+	obj && typeof obj === "object" && obj.isSprite;

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -9,6 +9,7 @@ import { initSplashListeners } from "./waitingSplash";
 import { initEssenceListeners } from "./essence";
 import { initClockListeners } from "./clock";
 import { initLogin } from "./login";
+import { currentGame, wrapGame } from "../gameContext";
 
 enum MouseButton {
 	LEFT = 0,
@@ -43,11 +44,11 @@ class UI {
 	constructor() {
 		emitter(this);
 
-		const game = Game.current;
+		const game = currentGame();
 
 		window.addEventListener(
 			"keydown",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				if (e.key === "f" && e.ctrlKey) e.preventDefault();
 
 				this.dispatchEvent("keyDown", {
@@ -60,7 +61,7 @@ class UI {
 
 		window.addEventListener(
 			"keyup",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				this.dispatchEvent("keyUp", {
 					ctrlDown: e.ctrlKey,
 					game,
@@ -71,7 +72,7 @@ class UI {
 
 		window.addEventListener(
 			"mousemove",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				this.dispatchEvent("mouseMove", {
 					target: e.target,
 					x: e.clientX,
@@ -82,7 +83,7 @@ class UI {
 
 		window.addEventListener(
 			"mouseout",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				this.dispatchEvent("mouseOut", {
 					relatedTarget: e.relatedTarget,
 				});
@@ -91,7 +92,7 @@ class UI {
 
 		window.addEventListener(
 			"mousedown",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				this.dispatchEvent("mouseDown", {
 					button: e.button,
 					ctrlDown: e.ctrlKey,
@@ -105,7 +106,7 @@ class UI {
 
 		window.addEventListener(
 			"wheel",
-			Game.wrap(game, (e) => {
+			wrapGame(game, (e) => {
 				this.dispatchEvent("wheel", {
 					deltaY: e.deltaY,
 				});

--- a/src/util/tweenPoints.ts
+++ b/src/util/tweenPoints.ts
@@ -267,20 +267,24 @@ export const tweenPoints = (points: Point[]): PathTweener => {
 	} as any);
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+const isPoint = (target: Object): target is Point =>
+	"x" in target && "y" in target;
+
 export const calcAndTweenShortenedPath = (
 	entity: Sprite,
 	target: Point | Sprite,
 	distanceToShorten: number,
 ): PathTweener => {
 	// Normalize the target
-	const targetPoint = Sprite.isSprite(target) ? target.position : target;
+	const targetPoint = isPoint(target) ? target : target.position;
 
 	// Calculate the path, which may not get to the target
-	const path = Sprite.isSprite(target)
-		? entity.round.pathingMap.withoutEntity(target, () =>
+	const path = isPoint(target)
+		? entity.round.pathingMap.path(entity, targetPoint)
+		: entity.round.pathingMap.withoutEntity(target, () =>
 				entity.round.pathingMap.path(entity, targetPoint),
-		  )
-		: entity.round.pathingMap.path(entity, targetPoint);
+		  );
 
 	// Check how far we are away from the target and get remaining distance
 	// E.g., if we don't make it to the target, we don't need to shorten (as

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"alwaysStrict": true,
 		"strictNullChecks": true,
 		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"types": [
 			"@types/jest",
 			"@types/node"


### PR DESCRIPTION
This is done with two strategies:
- Create type guards that don't do `instanceof` (instead, for Sprite, we add a `isSprite` prop and check for it).
- Move App and Game contexts outside their classes, resulting in us not needing the entire class to get the current instance.