### PR TITLE
Remove System#dirty and change Component generic default to unknown[]

### DIFF
--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -6,16 +6,13 @@ import { Entity } from "./Entity";
 import { withApp } from "./appContext";
 
 export class App {
+	protected entities: Entity[] = [];
 	protected systems: System[] = [];
 	protected mechanisms: Mechanism[] = [];
 	private lastRender = 0;
 	private requestedAnimationFrame?: number;
 	private _time = 0;
-	private componentUpdateMap = new Map<
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		ComponentConstructor<any>,
-		System[]
-	>();
+	private componentUpdateMap = new Map<ComponentConstructor, System[]>();
 	private components: typeof Component[] = [];
 	// TODO: make this private!
 	lastUpdate = 0;
@@ -85,8 +82,7 @@ export class App {
 	 */
 	entityComponentUpdated(
 		entity: Entity,
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		component: ComponentConstructor<any>,
+		component: ComponentConstructor,
 	): void {
 		const arr = this.componentUpdateMap.get(component);
 		if (!arr) return;

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -3,7 +3,7 @@ import { Entity } from "./Entity";
 import { isReplacingComponent, whileReplacingComponent } from "./util/flags";
 
 export class Component<
-	InitializationParameters extends unknown[] = [],
+	InitializationParameters extends unknown[] = unknown[],
 	E extends Entity = Entity
 > {
 	static has(entity: Entity): boolean {
@@ -27,7 +27,7 @@ export class Component<
 
 		currentApp().entityComponentUpdated(
 			entity,
-			<ComponentConstructor<Component>>this.constructor,
+			<ComponentConstructor>this.constructor,
 		);
 	}
 
@@ -39,7 +39,7 @@ export class Component<
 		if (!isReplacingComponent())
 			currentApp().entityComponentUpdated(
 				this.entity,
-				this.constructor as ComponentConstructor<Component>,
+				this.constructor as ComponentConstructor,
 			);
 	}
 
@@ -67,7 +67,7 @@ export class Component<
 	}
 }
 
-export type ComponentConstructor<T extends Component> = new (
+export type ComponentConstructor<T extends Component = Component> = new (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	...args: any[]
 ) => T;

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -6,7 +6,7 @@ export class Entity {
 	isEntity = true;
 	id: EntityID;
 
-	private map = new Map<ComponentConstructor<Component>, Component[]>();
+	private map = new Map<ComponentConstructor, Component[]>();
 
 	constructor(id: EntityID) {
 		this.id = id;
@@ -16,7 +16,7 @@ export class Entity {
 	 * If `klass` is not passed, returns all components on `this`. Otherwise,
 	 * returns the components of type `C` on `this`.
 	 */
-	get<K extends ComponentConstructor<Component<unknown[]>>>(
+	get<K extends ComponentConstructor>(
 		klass?: K,
 	): ReadonlyArray<InstanceType<K> | undefined> {
 		// Casting to C[] here means we're casting to Component<any>[], which is
@@ -39,7 +39,7 @@ export class Entity {
 		this.map.set(klass, components);
 	}
 
-	has<K extends ComponentConstructor<Component>>(klass: K): boolean {
+	has<K extends ComponentConstructor>(klass: K): boolean {
 		return (this.map.get(klass)?.length ?? 0) > 0;
 	}
 
@@ -48,11 +48,7 @@ export class Entity {
 	 * passed, all components of that type are cleared. If a specific component
 	 * is passed, that component is cleared.
 	 */
-	clear<
-		T extends
-			| Component<unknown[]>
-			| ComponentConstructor<Component<unknown[]>>
-	>(arg?: T): boolean {
+	clear<T extends Component | ComponentConstructor>(arg?: T): boolean {
 		let cleared = false;
 
 		// Clear all components
@@ -69,7 +65,7 @@ export class Entity {
 
 		// Clearing all components of type
 		if (typeof arg === "function") {
-			const klass = arg as ComponentConstructor<Component<unknown[]>>;
+			const klass = arg as ComponentConstructor;
 			const components = this.map.get(klass);
 			if (!components) return false;
 			this.map.set(klass, []);
@@ -84,9 +80,7 @@ export class Entity {
 
 		// Clear a specific component
 		const component = arg as Component<unknown[]>;
-		const klass = arg.constructor as ComponentConstructor<
-			Component<unknown[]>
-		>;
+		const klass = arg.constructor as ComponentConstructor;
 		const components = this.map.get(klass);
 		if (!components) return false;
 

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -4,7 +4,6 @@ import { Entity } from "./Entity";
 
 abstract class System<T extends Entity = Entity> {
 	private set: Set<T> = new Set();
-	protected dirty?: Set<T>;
 	private _callbacks: Map<
 		Entity,
 		{
@@ -12,17 +11,12 @@ abstract class System<T extends Entity = Entity> {
 		}
 	> = new Map();
 
-	static readonly components: ReadonlyArray<
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		ComponentConstructor<any>
-	> = [];
+	static readonly components: ReadonlyArray<ComponentConstructor> = [];
 
 	abstract test(entity: Entity | T): entity is T;
 
 	private _add(entity: T): void {
 		this.set.add(entity);
-		this.dirty?.add(entity);
-
 		this.onAddEntity?.(entity);
 	}
 
@@ -33,7 +27,6 @@ abstract class System<T extends Entity = Entity> {
 
 	private _remove(entity: Entity): void {
 		this.set.delete(entity as T);
-		this.dirty?.delete(entity as T);
 		this.onRemoveEntity?.(entity);
 	}
 
@@ -78,7 +71,7 @@ abstract class System<T extends Entity = Entity> {
 	}
 
 	[Symbol.iterator](): IterableIterator<T> {
-		return (this.dirty ?? this.set)[Symbol.iterator]();
+		return this.set[Symbol.iterator]();
 	}
 }
 

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -10,7 +10,6 @@ import { alea } from "./lib/alea";
 import { Settings } from "./types";
 import { Network, NetworkEventCallback } from "./network";
 import { UI } from "../ui/index";
-// import { initObstructionPlacement } from "./entities/sprites/obstructionPlacement";
 import { initPlayerLogic } from "./players/playerLogic";
 import { initSpriteLogicListeners } from "../entities/sprites/spriteLogic";
 import { App } from "../core/App";

--- a/src/engine/systems/ThreeGraphics.ts
+++ b/src/engine/systems/ThreeGraphics.ts
@@ -99,7 +99,6 @@ export class ThreeGraphics extends System {
 	static isThreeGraphics = (system: System): system is ThreeGraphics =>
 		system instanceof ThreeGraphics;
 
-	protected dirty = new Set<Entity>();
 	private entityData: Map<Entity, EntityData> = new Map();
 	private renderer: WebGLRenderer;
 	private scene: Scene;


### PR DESCRIPTION
- Removes the `dirty` set from `System`, which is no longer used.
- Changes `Component` default params to `unknown[]`, killing need for `any` in various places.

Resolves #46.